### PR TITLE
Removed the annotation as it is not needed.

### DIFF
--- a/network/ingress-hello-minikube.yml
+++ b/network/ingress-hello-minikube.yml
@@ -2,8 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hello
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
     - host: hello.example.com


### PR DESCRIPTION
The nginx annotation is not needed. It doesn't hurt having it, but the YAML is simpler without it.