### PR TITLE
bugfix(DO100-8): fix PowerShell script

### DIFF
--- a/setup/windows/setup.ps1
+++ b/setup/windows/setup.ps1
@@ -139,6 +139,7 @@ function apply_role_resources(${1}) {
     Write-Host "Creating role resources for user '${USERNAME}' in namespace '${1}' ..."
     $NEWYML | Set-Content -Path $SCRIPTPATH\files\role-binding.yml
     kubectl apply -f $SCRIPTPATH\files\role-binding.yml --validate=false
+    $OLDYML | Set-Content -Path $SCRIPTPATH\files\role-binding.yml
     }
 }
 


### PR DESCRIPTION
Fixes https://training-feedback.redhat.com/browse/DO100-8. 

The `apply_role_resources` function was not restoring the original `role-binding.yml` after each execution.